### PR TITLE
Fix access beyond known buffer size

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -257,7 +257,7 @@ int best_group(size_t idx) {
       return -1;
   }
 
-  while (ptr->Size > 0 && byteOffset + ptr->Size <= returnLength)
+  while (byteOffset < returnLength)
   {
       if (ptr->Relationship == RelationNumaNode)
           nodes++;


### PR DESCRIPTION
Addressing https://github.com/official-stockfish/Stockfish/issues/1891
When iterating through 'SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX' structure, do not use structure member beyond known size.

The 'Size' field here is self-inclusive, so it is not possible to have an element that contains 'Size = 0'.

No functional change.