### PR TITLE
Stop probing livebook, after the first out-of-book move.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -154,6 +154,7 @@ namespace {
 /// Search::init() is called at startup to initialize various lookup tables
 
 CURL *g_cURL;
+bool inbook;
 std::string g_szRecv;
 size_t cURL_WriteFunc(void *contents, size_t size, size_t nmemb, std::string *s)
 {
@@ -190,6 +191,7 @@ void Search::clear() {
 
   Threads.main()->wait_for_search_finished();
 
+  inbook = true;
   Time.availableNodes = 0;
   TT.clear();
   Threads.clear();
@@ -223,7 +225,7 @@ void MainThread::search() {
   else
   {
     Move bookMove = MOVE_NONE;
-    if (!Limits.infinite && !Limits.mate)
+    if (!Limits.infinite && !Limits.mate && inbook)
     {
       CURLcode res;
       char *szFen = curl_easy_escape(g_cURL, rootPos.fen().c_str(), 0);
@@ -254,6 +256,7 @@ void MainThread::search() {
     }
     else
     {
+       inbook = false;
         for (Thread* th : Threads)
         {
             th->bestMoveChanges = 0;


### PR DESCRIPTION
this improves performance significantly if the connection is slow. It assumes we won't transpose in the book after the first book exit.